### PR TITLE
Unwind and cleanup sysroot

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -696,83 +696,83 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator + ?Sized> FusedIterator for Box<I> {}
 
-// #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-// impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
-//     type Output = <F as FnOnce<A>>::Output;
+#[stable(feature = "boxed_closure_impls", since = "1.35.0")]
+impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
+    type Output = <F as FnOnce<A>>::Output;
 
-//     extern "rust-call" fn call_once(self, args: A) -> Self::Output {
-//         <F as FnOnce<A>>::call_once(*self, args)
-//     }
-// }
+    extern "rust-call" fn call_once(self, args: A) -> Self::Output {
+        <F as FnOnce<A>>::call_once(*self, args)
+    }
+}
 
-// #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-// impl<A, F: FnMut<A> + ?Sized> FnMut<A> for Box<F> {
-//     extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
-//         <F as FnMut<A>>::call_mut(self, args)
-//     }
-// }
+#[stable(feature = "boxed_closure_impls", since = "1.35.0")]
+impl<A, F: FnMut<A> + ?Sized> FnMut<A> for Box<F> {
+    extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
+        <F as FnMut<A>>::call_mut(self, args)
+    }
+}
 
-// #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-// impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
-//     extern "rust-call" fn call(&self, args: A) -> Self::Output {
-//         <F as Fn<A>>::call(self, args)
-//     }
-// }
+#[stable(feature = "boxed_closure_impls", since = "1.35.0")]
+impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
+    extern "rust-call" fn call(&self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(self, args)
+    }
+}
 
-// /// `FnBox` is a version of the `FnOnce` intended for use with boxed
-// /// closure objects. The idea is that where one would normally store a
-// /// `Box<dyn FnOnce()>` in a data structure, you should use
-// /// `Box<dyn FnBox()>`. The two traits behave essentially the same, except
-// /// that a `FnBox` closure can only be called if it is boxed. (Note
-// /// that `FnBox` may be deprecated in the future if `Box<dyn FnOnce()>`
-// /// closures become directly usable.)
-// ///
-// /// # Examples
-// ///
-// /// Here is a snippet of code which creates a hashmap full of boxed
-// /// once closures and then removes them one by one, calling each
-// /// closure as it is removed. Note that the type of the closures
-// /// stored in the map is `Box<dyn FnBox() -> i32>` and not `Box<dyn FnOnce()
-// /// -> i32>`.
-// ///
-// /// ```
-// /// #![feature(fnbox)]
-// ///
-// /// use std::boxed::FnBox;
-// /// use std::collections::HashMap;
-// ///
-// /// fn make_map() -> HashMap<i32, Box<dyn FnBox() -> i32>> {
-// ///     let mut map: HashMap<i32, Box<dyn FnBox() -> i32>> = HashMap::new();
-// ///     map.insert(1, Box::new(|| 22));
-// ///     map.insert(2, Box::new(|| 44));
-// ///     map
-// /// }
-// ///
-// /// fn main() {
-// ///     let mut map = make_map();
-// ///     for i in &[1, 2] {
-// ///         let f = map.remove(&i).unwrap();
-// ///         assert_eq!(f(), i * 22);
-// ///     }
-// /// }
-// /// ```
-// #[rustc_paren_sugar]
-// #[unstable(feature = "fnbox",
-//            reason = "will be deprecated if and when `Box<FnOnce>` becomes usable", issue = "28796")]
-// pub trait FnBox<A>: FnOnce<A> {
-//     /// Performs the call operation.
-//     fn call_box(self: Box<Self>, args: A) -> Self::Output;
-// }
+/// `FnBox` is a version of the `FnOnce` intended for use with boxed
+/// closure objects. The idea is that where one would normally store a
+/// `Box<dyn FnOnce()>` in a data structure, you should use
+/// `Box<dyn FnBox()>`. The two traits behave essentially the same, except
+/// that a `FnBox` closure can only be called if it is boxed. (Note
+/// that `FnBox` may be deprecated in the future if `Box<dyn FnOnce()>`
+/// closures become directly usable.)
+///
+/// # Examples
+///
+/// Here is a snippet of code which creates a hashmap full of boxed
+/// once closures and then removes them one by one, calling each
+/// closure as it is removed. Note that the type of the closures
+/// stored in the map is `Box<dyn FnBox() -> i32>` and not `Box<dyn FnOnce()
+/// -> i32>`.
+///
+/// ```
+/// #![feature(fnbox)]
+///
+/// use std::boxed::FnBox;
+/// use std::collections::HashMap;
+///
+/// fn make_map() -> HashMap<i32, Box<dyn FnBox() -> i32>> {
+///     let mut map: HashMap<i32, Box<dyn FnBox() -> i32>> = HashMap::new();
+///     map.insert(1, Box::new(|| 22));
+///     map.insert(2, Box::new(|| 44));
+///     map
+/// }
+///
+/// fn main() {
+///     let mut map = make_map();
+///     for i in &[1, 2] {
+///         let f = map.remove(&i).unwrap();
+///         assert_eq!(f(), i * 22);
+///     }
+/// }
+/// ```
+#[rustc_paren_sugar]
+#[unstable(feature = "fnbox",
+           reason = "will be deprecated if and when `Box<FnOnce>` becomes usable", issue = "28796")]
+pub trait FnBox<A>: FnOnce<A> {
+    /// Performs the call operation.
+    fn call_box(self: Box<Self>, args: A) -> Self::Output;
+}
 
-// #[unstable(feature = "fnbox",
-//            reason = "will be deprecated if and when `Box<FnOnce>` becomes usable", issue = "28796")]
-// impl<A, F> FnBox<A> for F
-//     where F: FnOnce<A>
-// {
-//     fn call_box(self: Box<F>, args: A) -> F::Output {
-//         self.call_once(args)
-//     }
-// }
+#[unstable(feature = "fnbox",
+           reason = "will be deprecated if and when `Box<FnOnce>` becomes usable", issue = "28796")]
+impl<A, F> FnBox<A> for F
+    where F: FnOnce<A>
+{
+    fn call_box(self: Box<F>, args: A) -> F::Output {
+        self.call_once(args)
+    }
+}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -144,7 +144,7 @@ mod boxed {
 #[cfg(test)]
 mod boxed_test;
 pub mod collections;
-// #[cfg(all(target_has_atomic = "ptr", target_has_atomic = "cas"))]
+#[cfg(all(target_has_atomic = "ptr", target_has_atomic = "cas"))]
 pub mod sync;
 pub mod rc;
 pub mod raw_vec;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -5,7 +5,8 @@
 use crate::cell::{UnsafeCell, Cell, RefCell, Ref, RefMut};
 use crate::marker::PhantomData;
 use crate::mem;
-// use crate::num::flt2dec;
+#[cfg(not(target_arch = "bpf"))]
+use crate::num::flt2dec;
 use crate::ops::Deref;
 use crate::result;
 use crate::slice;
@@ -1328,85 +1329,87 @@ impl<'a> Formatter<'a> {
         Ok(PostPadding::new(self.fill, post_pad))
     }
 
-    // /// Takes the formatted parts and applies the padding.
-    // /// Assumes that the caller already has rendered the parts with required precision,
-    // /// so that `self.precision` can be ignored.
-    // fn pad_formatted_parts(&mut self, formatted: &flt2dec::Formatted<'_>) -> Result {
-    //     if let Some(mut width) = self.width {
-    //         // for the sign-aware zero padding, we render the sign first and
-    //         // behave as if we had no sign from the beginning.
-    //         let mut formatted = formatted.clone();
-    //         let old_fill = self.fill;
-    //         let old_align = self.align;
-    //         let mut align = old_align;
-    //         if self.sign_aware_zero_pad() {
-    //             // a sign always goes first
-    //             let sign = unsafe { str::from_utf8_unchecked(formatted.sign) };
-    //             self.buf.write_str(sign)?;
+    /// Takes the formatted parts and applies the padding.
+    /// Assumes that the caller already has rendered the parts with required precision,
+    /// so that `self.precision` can be ignored.
+    #[cfg(not(target_arch = "bpf"))]
+    fn pad_formatted_parts(&mut self, formatted: &flt2dec::Formatted<'_>) -> Result {
+        if let Some(mut width) = self.width {
+            // for the sign-aware zero padding, we render the sign first and
+            // behave as if we had no sign from the beginning.
+            let mut formatted = formatted.clone();
+            let old_fill = self.fill;
+            let old_align = self.align;
+            let mut align = old_align;
+            if self.sign_aware_zero_pad() {
+                // a sign always goes first
+                let sign = unsafe { str::from_utf8_unchecked(formatted.sign) };
+                self.buf.write_str(sign)?;
 
-    //             // remove the sign from the formatted parts
-    //             formatted.sign = b"";
-    //             width = width.saturating_sub(sign.len());
-    //             align = rt::v1::Alignment::Right;
-    //             self.fill = '0';
-    //             self.align = rt::v1::Alignment::Right;
-    //         }
+                // remove the sign from the formatted parts
+                formatted.sign = b"";
+                width = width.saturating_sub(sign.len());
+                align = rt::v1::Alignment::Right;
+                self.fill = '0';
+                self.align = rt::v1::Alignment::Right;
+            }
 
-    //         // remaining parts go through the ordinary padding process.
-    //         let len = formatted.len();
-    //         let ret = if width <= len { // no padding
-    //             self.write_formatted_parts(&formatted)
-    //         } else {
-    //             let post_padding = self.padding(width - len, align)?;
-    //             self.write_formatted_parts(&formatted)?;
-    //             post_padding.write(self.buf)
-    //         };
-    //         self.fill = old_fill;
-    //         self.align = old_align;
-    //         ret
-    //     } else {
-    //         // this is the common case and we take a shortcut
-    //         self.write_formatted_parts(formatted)
-    //     }
-    // }
+            // remaining parts go through the ordinary padding process.
+            let len = formatted.len();
+            let ret = if width <= len { // no padding
+                self.write_formatted_parts(&formatted)
+            } else {
+                let post_padding = self.padding(width - len, align)?;
+                self.write_formatted_parts(&formatted)?;
+                post_padding.write(self.buf)
+            };
+            self.fill = old_fill;
+            self.align = old_align;
+            ret
+        } else {
+            // this is the common case and we take a shortcut
+            self.write_formatted_parts(formatted)
+        }
+    }
 
-    // fn write_formatted_parts(&mut self, formatted: &flt2dec::Formatted<'_>) -> Result {
-    //     fn write_bytes(buf: &mut dyn Write, s: &[u8]) -> Result {
-    //         buf.write_str(unsafe { str::from_utf8_unchecked(s) })
-    //     }
+    #[cfg(not(target_arch = "bpf"))]
+    fn write_formatted_parts(&mut self, formatted: &flt2dec::Formatted<'_>) -> Result {
+        fn write_bytes(buf: &mut dyn Write, s: &[u8]) -> Result {
+            buf.write_str(unsafe { str::from_utf8_unchecked(s) })
+        }
 
-    //     if !formatted.sign.is_empty() {
-    //         write_bytes(self.buf, formatted.sign)?;
-    //     }
-    //     for part in formatted.parts {
-    //         match *part {
-    //             flt2dec::Part::Zero(mut nzeroes) => {
-    //                 const ZEROES: &str = // 64 zeroes
-    //                     "0000000000000000000000000000000000000000000000000000000000000000";
-    //                 while nzeroes > ZEROES.len() {
-    //                     self.buf.write_str(ZEROES)?;
-    //                     nzeroes -= ZEROES.len();
-    //                 }
-    //                 if nzeroes > 0 {
-    //                     self.buf.write_str(&ZEROES[..nzeroes])?;
-    //                 }
-    //             }
-    //             flt2dec::Part::Num(mut v) => {
-    //                 let mut s = [0; 5];
-    //                 let len = part.len();
-    //                 for c in s[..len].iter_mut().rev() {
-    //                     *c = b'0' + (v % 10) as u8;
-    //                     v /= 10;
-    //                 }
-    //                 write_bytes(self.buf, &s[..len])?;
-    //             }
-    //             flt2dec::Part::Copy(buf) => {
-    //                 write_bytes(self.buf, buf)?;
-    //             }
-    //         }
-    //     }
-    //     Ok(())
-    // }
+        if !formatted.sign.is_empty() {
+            write_bytes(self.buf, formatted.sign)?;
+        }
+        for part in formatted.parts {
+            match *part {
+                flt2dec::Part::Zero(mut nzeroes) => {
+                    const ZEROES: &str = // 64 zeroes
+                        "0000000000000000000000000000000000000000000000000000000000000000";
+                    while nzeroes > ZEROES.len() {
+                        self.buf.write_str(ZEROES)?;
+                        nzeroes -= ZEROES.len();
+                    }
+                    if nzeroes > 0 {
+                        self.buf.write_str(&ZEROES[..nzeroes])?;
+                    }
+                }
+                flt2dec::Part::Num(mut v) => {
+                    let mut s = [0; 5];
+                    let len = part.len();
+                    for c in s[..len].iter_mut().rev() {
+                        *c = b'0' + (v % 10) as u8;
+                        v /= 10;
+                    }
+                    write_bytes(self.buf, &s[..len])?;
+                }
+                flt2dec::Part::Copy(buf) => {
+                    write_bytes(self.buf, buf)?;
+                }
+            }
+        }
+        Ok(())
+    }
 
     /// Writes some data to the underlying buffer contained within this
     /// formatter.

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1011,11 +1011,11 @@ pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     match args.fmt {
         None => {
             // We can use default formatting parameters for all arguments.
-            // for (arg, piece) in args.args.iter().zip(args.pieces.iter()) {
-                // formatter.buf.write_str(*piece)?;
-                // (arg.formatter)(arg.value, &mut formatter)?;
-                // idx += 1;
-            // }
+            for (arg, piece) in args.args.iter().zip(args.pieces.iter()) {
+                formatter.buf.write_str(*piece)?;
+                (arg.formatter)(arg.value, &mut formatter)?;
+                idx += 1;
+            }
         }
         Some(fmt) => {
             // Every spec has a corresponding argument that is preceded by

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -74,34 +74,34 @@ pub unsafe fn unreachable_unchecked() -> ! {
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
-    // #[cfg(
-    //     all(
-    //         any(target_arch = "x86", target_arch = "x86_64"),
-    //         target_feature = "sse2"
-    //     )
-    // )] {
-    //     #[cfg(target_arch = "x86")] {
-    //         unsafe { crate::arch::x86::_mm_pause() };
-    //     }
+    #[cfg(
+        all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse2"
+        )
+    )] {
+        #[cfg(target_arch = "x86")] {
+            unsafe { crate::arch::x86::_mm_pause() };
+        }
 
-    //     #[cfg(target_arch = "x86_64")] {
-    //         unsafe { crate::arch::x86_64::_mm_pause() };
-    //     }
-    // }
+        #[cfg(target_arch = "x86_64")] {
+            unsafe { crate::arch::x86_64::_mm_pause() };
+        }
+    }
 
-    // #[cfg(
-    //     any(
-    //         target_arch = "aarch64",
-    //         all(target_arch = "arm", target_feature = "v6")
-    //     )
-    // )] {
-    //     #[cfg(target_arch = "aarch64")] {
-    //         unsafe { crate::arch::aarch64::__yield() };
-    //     }
-    //     #[cfg(target_arch = "arm")] {
-    //         unsafe { crate::arch::arm::__yield() };
-    //     }
-    // }
+    #[cfg(
+        any(
+            target_arch = "aarch64",
+            all(target_arch = "arm", target_feature = "v6")
+        )
+    )] {
+        #[cfg(target_arch = "aarch64")] {
+            unsafe { crate::arch::aarch64::__yield() };
+        }
+        #[cfg(target_arch = "arm")] {
+            unsafe { crate::arch::arm::__yield() };
+        }
+    }
 }
 
 /// A function that is opaque to the optimizer, to allow benchmarks to

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -127,10 +127,11 @@ pub mod estimator;
 pub mod decoder;
 
 /// Digit-generation algorithms.
-// pub mod strategy {
-//     pub mod dragon;
-//     pub mod grisu;
-// }
+#[cfg(not(target_arch = "bpf"))]
+pub mod strategy {
+    pub mod dragon;
+    pub mod grisu;
+}
 
 /// The minimum size of buffer necessary for the shortest mode.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2652,10 +2652,10 @@ macro_rules! fnptr_impls_args {
     ($($Arg: ident),+) => {
         fnptr_impls_safety_abi! { extern "Rust" fn($($Arg),*) -> Ret, $($Arg),* }
         fnptr_impls_safety_abi! { extern "C" fn($($Arg),*) -> Ret, $($Arg),* }
-        // fnptr_impls_safety_abi! { extern "C" fn($($Arg),* , ...) -> Ret, $($Arg),* }
+        fnptr_impls_safety_abi! { extern "C" fn($($Arg),* , ...) -> Ret, $($Arg),* }
         fnptr_impls_safety_abi! { unsafe extern "Rust" fn($($Arg),*) -> Ret, $($Arg),* }
         fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),*) -> Ret, $($Arg),* }
-        // fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),* , ...) -> Ret, $($Arg),* }
+        fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),* , ...) -> Ret, $($Arg),* }
     };
     () => {
         // No variadic functions with 0 parameters

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -118,7 +118,7 @@
 
 use self::Ordering::*;
 
-// use crate::intrinsics;
+use crate::intrinsics;
 use crate::cell::UnsafeCell;
 use crate::fmt;
 
@@ -181,7 +181,7 @@ unsafe impl Sync for AtomicBool {}
 /// A raw pointer type which can be safely shared between threads.
 ///
 /// This type has the same in-memory representation as a `*mut T`.
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(target_pointer_width = "16", repr(C, align(2)))]
 #[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
@@ -190,7 +190,7 @@ pub struct AtomicPtr<T> {
     p: UnsafeCell<*mut T>,
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for AtomicPtr<T> {
     /// Creates a null `AtomicPtr<T>`.
@@ -199,10 +199,10 @@ impl<T> Default for AtomicPtr<T> {
     }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Send for AtomicPtr<T> {}
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Sync for AtomicPtr<T> {}
 
@@ -397,9 +397,8 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn load(&self, _order: Ordering) -> bool {
-        // unsafe { atomic_load(self.v.get(), order) != 0 }
-        true
+    pub fn load(&self, order: Ordering) -> bool {
+        unsafe { atomic_load(self.v.get(), order) != 0 }
     }
 
     /// Stores a value into the bool.
@@ -430,10 +429,10 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn store(&self, _val: bool, _order: Ordering) {
-        // unsafe {
-        //     atomic_store(self.v.get(), val as u8, order);
-        // }
+    pub fn store(&self, val: bool, order: Ordering) {
+        unsafe {
+            atomic_store(self.v.get(), val as u8, order);
+        }
     }
 
     /// Stores a value into the bool, returning the previous value.
@@ -461,9 +460,8 @@ impl AtomicBool {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "cas")]
-    pub fn swap(&self, _val: bool, _order: Ordering) -> bool {
-        // unsafe { atomic_swap(self.v.get(), val as u8, order) != 0 }
-        true
+    pub fn swap(&self, val: bool, order: Ordering) -> bool {
+        unsafe { atomic_swap(self.v.get(), val as u8, order) != 0 }
     }
 
     /// Stores a value into the [`bool`] if the current value is the same as the `current` value.
@@ -499,7 +497,7 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_and_swap(&self, current: bool, new: bool, order: Ordering) -> bool {
         match self.compare_exchange(current, new, order, strongest_failure_ordering(order)) {
             Ok(x) => x,
@@ -550,20 +548,19 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_exchange(&self,
-                            _current: bool,
-                            _new: bool,
-                            _success: Ordering,
-                            _failure: Ordering)
+                            current: bool,
+                            new: bool,
+                            success: Ordering,
+                            failure: Ordering)
                             -> Result<bool, bool> {
-        // match unsafe {
-        //     atomic_compare_exchange(self.v.get(), current as u8, new as u8, success, failure)
-        // } {
-        //     Ok(x) => Ok(x != 0),
-        //     Err(x) => Err(x != 0),
-        // }
-        Ok(true)
+        match unsafe {
+            atomic_compare_exchange(self.v.get(), current as u8, new as u8, success, failure)
+        } {
+            Ok(x) => Ok(x != 0),
+            Err(x) => Err(x != 0),
+        }
     }
 
     /// Stores a value into the [`bool`] if the current value is the same as the `current` value.
@@ -607,20 +604,19 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_exchange_weak(&self,
-                                 _current: bool,
-                                 _new: bool,
-                                 _success: Ordering,
-                                 _failure: Ordering)
+                                 current: bool,
+                                 new: bool,
+                                 success: Ordering,
+                                 failure: Ordering)
                                  -> Result<bool, bool> {
-        // match unsafe {
-        //     atomic_compare_exchange_weak(self.v.get(), current as u8, new as u8, success, failure)
-        // } {
-        //     Ok(x) => Ok(x != 0),
-        //     Err(x) => Err(x != 0),
-        // }
-        Ok(true)
+        match unsafe {
+            atomic_compare_exchange_weak(self.v.get(), current as u8, new as u8, success, failure)
+        } {
+            Ok(x) => Ok(x != 0),
+            Err(x) => Err(x != 0),
+        }
     }
 
     /// Logical "and" with a boolean value.
@@ -659,10 +655,9 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
-    pub fn fetch_and(&self, _val: bool, _order: Ordering) -> bool {
-        // unsafe { atomic_and(self.v.get(), val as u8, order) != 0 }
-        true
+    #[cfg(target_has_atomic = "cas")]
+    pub fn fetch_and(&self, val: bool, order: Ordering) -> bool {
+        unsafe { atomic_and(self.v.get(), val as u8, order) != 0 }
     }
 
     /// Logical "nand" with a boolean value.
@@ -702,22 +697,21 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
-    pub fn fetch_nand(&self, _val: bool, _order: Ordering) -> bool {
-        // // We can't use atomic_nand here because it can result in a bool with
-        // // an invalid value. This happens because the atomic operation is done
-        // // with an 8-bit integer internally, which would set the upper 7 bits.
-        // // So we just use fetch_xor or swap instead.
-        // if val {
-        //     // !(x & true) == !x
-        //     // We must invert the bool.
-        //     self.fetch_xor(true, order)
-        // } else {
-        //     // !(x & false) == true
-        //     // We must set the bool to true.
-        //     self.swap(true, order)
-        // }
-        true
+    #[cfg(target_has_atomic = "cas")]
+    pub fn fetch_nand(&self, val: bool, order: Ordering) -> bool {
+        // We can't use atomic_nand here because it can result in a bool with
+        // an invalid value. This happens because the atomic operation is done
+        // with an 8-bit integer internally, which would set the upper 7 bits.
+        // So we just use fetch_xor or swap instead.
+        if val {
+            // !(x & true) == !x
+            // We must invert the bool.
+            self.fetch_xor(true, order)
+        } else {
+            // !(x & false) == true
+            // We must set the bool to true.
+            self.swap(true, order)
+        }
     }
 
     /// Logical "or" with a boolean value.
@@ -756,10 +750,9 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
-    pub fn fetch_or(&self, _val: bool, _order: Ordering) -> bool {
-        // unsafe { atomic_or(self.v.get(), val as u8, order) != 0 }
-        true
+    #[cfg(target_has_atomic = "cas")]
+    pub fn fetch_or(&self, val: bool, order: Ordering) -> bool {
+        unsafe { atomic_or(self.v.get(), val as u8, order) != 0 }
     }
 
     /// Logical "xor" with a boolean value.
@@ -798,14 +791,13 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
-    pub fn fetch_xor(&self, _val: bool, _order: Ordering) -> bool {
-        // unsafe { atomic_xor(self.v.get(), val as u8, order) != 0 }
-        true
+    #[cfg(target_has_atomic = "cas")]
+    pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
+        unsafe { atomic_xor(self.v.get(), val as u8, order) != 0 }
     }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> AtomicPtr<T> {
     /// Creates a new `AtomicPtr`.
     ///
@@ -890,9 +882,8 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn load(&self, _order: Ordering) -> *mut T {
-        // unsafe { atomic_load(self.p.get() as *mut usize, order) as *mut T }
-        self.p.get() as *mut T
+    pub fn load(&self, order: Ordering) -> *mut T {
+        unsafe { atomic_load(self.p.get() as *mut usize, order) as *mut T }
     }
 
     /// Stores a value into the pointer.
@@ -925,10 +916,10 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn store(&self, _ptr: *mut T, _order: Ordering) {
-        // unsafe {
-        //     atomic_store(self.p.get() as *mut usize, ptr as usize, order);
-        // }
+    pub fn store(&self, ptr: *mut T, order: Ordering) {
+        unsafe {
+            atomic_store(self.p.get() as *mut usize, ptr as usize, order);
+        }
     }
 
     /// Stores a value into the pointer, returning the previous value.
@@ -957,10 +948,9 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
-    pub fn swap(&self, ptr: *mut T, _order: Ordering) -> *mut T {
-        // unsafe { atomic_swap(self.p.get() as *mut usize, ptr as usize, order) as *mut T }
-        ptr
+    #[cfg(target_has_atomic = "cas")]
+    pub fn swap(&self, ptr: *mut T, order: Ordering) -> *mut T {
+        unsafe { atomic_swap(self.p.get() as *mut usize, ptr as usize, order) as *mut T }
     }
 
     /// Stores a value into the pointer if the current value is the same as the `current` value.
@@ -995,7 +985,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_and_swap(&self, current: *mut T, new: *mut T, order: Ordering) -> *mut T {
         match self.compare_exchange(current, new, order, strongest_failure_ordering(order)) {
             Ok(x) => x,
@@ -1038,25 +1028,24 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_exchange(&self,
                             current: *mut T,
-                            _new: *mut T,
-                            _success: Ordering,
-                            _failure: Ordering)
+                            new: *mut T,
+                            success: Ordering,
+                            failure: Ordering)
                             -> Result<*mut T, *mut T> {
-        // unsafe {
-        //     let res = atomic_compare_exchange(self.p.get() as *mut usize,
-        //                                       current as usize,
-        //                                       new as usize,
-        //                                       success,
-        //                                       failure);
-        //     match res {
-        //         Ok(x) => Ok(x as *mut T),
-        //         Err(x) => Err(x as *mut T),
-        //     }
-        // }
-        Ok(current)
+        unsafe {
+            let res = atomic_compare_exchange(self.p.get() as *mut usize,
+                                              current as usize,
+                                              new as usize,
+                                              success,
+                                              failure);
+            match res {
+                Ok(x) => Ok(x as *mut T),
+                Err(x) => Err(x as *mut T),
+            }
+        }
     }
 
     /// Stores a value into the pointer if the current value is the same as the `current` value.
@@ -1099,25 +1088,24 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
-    // #[cfg(target_has_atomic = "cas")]
+    #[cfg(target_has_atomic = "cas")]
     pub fn compare_exchange_weak(&self,
                                  current: *mut T,
-                                 _new: *mut T,
-                                 _success: Ordering,
-                                 _failure: Ordering)
+                                 new: *mut T,
+                                 success: Ordering,
+                                 failure: Ordering)
                                  -> Result<*mut T, *mut T> {
-        // unsafe {
-        //     let res = atomic_compare_exchange_weak(self.p.get() as *mut usize,
-        //                                            current as usize,
-        //                                            new as usize,
-        //                                            success,
-        //                                            failure);
-        //     match res {
-        //         Ok(x) => Ok(x as *mut T),
-        //         Err(x) => Err(x as *mut T),
-        //     }
-        // }
-        Ok(current)
+        unsafe {
+            let res = atomic_compare_exchange_weak(self.p.get() as *mut usize,
+                                                   current as usize,
+                                                   new as usize,
+                                                   success,
+                                                   failure);
+            match res {
+                Ok(x) => Ok(x as *mut T),
+                Err(x) => Err(x as *mut T),
+            }
+        }
     }
 }
 
@@ -1137,14 +1125,14 @@ impl From<bool> for AtomicBool {
     fn from(b: bool) -> Self { Self::new(b) }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "atomic_from", since = "1.23.0")]
 impl<T> From<*mut T> for AtomicPtr<T> {
     #[inline]
     fn from(p: *mut T) -> Self { Self::new(p) }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 macro_rules! atomic_int {
     ($stable:meta,
      $stable_cxchg:meta,
@@ -1304,9 +1292,8 @@ assert_eq!(some_var.load(Ordering::Relaxed), 5);
 ```"),
                 #[inline]
                 #[$stable]
-                pub fn load(&self, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_load(self.v.get(), order) }
-                    0
+                pub fn load(&self, order: Ordering) -> $int_type {
+                    unsafe { atomic_load(self.v.get(), order) }
                 }
             }
 
@@ -1339,8 +1326,8 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
 ```"),
                 #[inline]
                 #[$stable]
-                pub fn store(&self, _val: $int_type, _order: Ordering) {
-                    // unsafe { atomic_store(self.v.get(), val, order); }
+                pub fn store(&self, val: $int_type, order: Ordering) {
+                    unsafe { atomic_store(self.v.get(), val, order); }
                 }
             }
 
@@ -1368,10 +1355,9 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn swap(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_swap(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_swap(self.v.get(), val, order) }
                 }
             }
 
@@ -1409,7 +1395,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn compare_and_swap(&self,
                                         current: $int_type,
                                         new: $int_type,
@@ -1467,14 +1453,13 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
 ```"),
                 #[inline]
                 #[$stable_cxchg]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn compare_exchange(&self,
                                         current: $int_type,
-                                        _new: $int_type,
-                                        _success: Ordering,
-                                        _failure: Ordering) -> Result<$int_type, $int_type> {
-                    // unsafe { atomic_compare_exchange(self.v.get(), current, new, success, failure) }
-                    Ok(current)
+                                        new: $int_type,
+                                        success: Ordering,
+                                        failure: Ordering) -> Result<$int_type, $int_type> {
+                    unsafe { atomic_compare_exchange(self.v.get(), current, new, success, failure) }
                 }
             }
 
@@ -1520,16 +1505,15 @@ loop {
 ```"),
                 #[inline]
                 #[$stable_cxchg]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn compare_exchange_weak(&self,
                                              current: $int_type,
-                                             _new: $int_type,
-                                             _success: Ordering,
-                                             _failure: Ordering) -> Result<$int_type, $int_type> {
-                    // unsafe {
-                    //     atomic_compare_exchange_weak(self.v.get(), current, new, success, failure)
-                    // }
-                    Ok(current)
+                                             new: $int_type,
+                                             success: Ordering,
+                                             failure: Ordering) -> Result<$int_type, $int_type> {
+                    unsafe {
+                        atomic_compare_exchange_weak(self.v.get(), current, new, success, failure)
+                    }
                 }
             }
 
@@ -1559,10 +1543,9 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_add(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_add(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_add(self.v.get(), val, order) }
                 }
             }
 
@@ -1592,10 +1575,9 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_sub(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_sub(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_sub(self.v.get(), val, order) }
                 }
             }
 
@@ -1628,10 +1610,9 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_and(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_and(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_and(self.v.get(), val, order) }
                 }
             }
 
@@ -1665,10 +1646,9 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
 ```"),
                 #[inline]
                 #[$stable_nand]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_nand(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_nand(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_nand(self.v.get(), val, order) }
                 }
             }
 
@@ -1701,10 +1681,9 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_or(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_or(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_or(self.v.get(), val, order) }
                 }
             }
 
@@ -1737,10 +1716,9 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
 ```"),
                 #[inline]
                 #[$stable]
-                // #[cfg(target_has_atomic = "cas")]
-                pub fn fetch_xor(&self, val: $int_type, _order: Ordering) -> $int_type {
-                    // unsafe { atomic_xor(self.v.get(), val, order) }
-                    val
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
+                    unsafe { atomic_xor(self.v.get(), val, order) }
                 }
             }
 
@@ -1788,7 +1766,7 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                 #[unstable(feature = "no_more_cas",
                        reason = "no more CAS loops in user code",
                        issue = "48655")]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn fetch_update<F>(&self,
                                        mut f: F,
                                        fetch_order: Ordering,
@@ -1849,7 +1827,7 @@ assert!(max_foo == 42);
                 #[unstable(feature = "atomic_min_max",
                        reason = "easier and faster min/max than writing manual CAS loop",
                        issue = "48655")]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
                     unsafe { $max_fn(self.v.get(), val, order) }
                 }
@@ -1901,7 +1879,7 @@ assert_eq!(min_foo, 12);
                 #[unstable(feature = "atomic_min_max",
                        reason = "easier and faster min/max than writing manual CAS loop",
                        issue = "48655")]
-                // #[cfg(target_has_atomic = "cas")]
+                #[cfg(target_has_atomic = "cas")]
                 pub fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
                     unsafe { $min_fn(self.v.get(), val, order) }
                 }
@@ -2083,7 +2061,7 @@ macro_rules! ptr_width {
 macro_rules! ptr_width {
     () => { 8 }
 }
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 atomic_int!{
     stable(feature = "rust1", since = "1.0.0"),
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
@@ -2099,7 +2077,7 @@ atomic_int!{
     "AtomicIsize::new(0)",
     isize AtomicIsize ATOMIC_ISIZE_INIT
 }
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 atomic_int!{
     stable(feature = "rust1", since = "1.0.0"),
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
@@ -2117,7 +2095,7 @@ atomic_int!{
 }
 
 #[inline]
-// #[cfg(target_has_atomic = "cas")]
+#[cfg(target_has_atomic = "cas")]
 fn strongest_failure_ordering(order: Ordering) -> Ordering {
     match order {
         Release => Relaxed,
@@ -2128,115 +2106,186 @@ fn strongest_failure_ordering(order: Ordering) -> Ordering {
     }
 }
 
-// #[inline]
-// unsafe fn atomic_store<T>(dst: *mut T, val: T, order: Ordering) {
-//     match order {
-//         Release => intrinsics::atomic_store_rel(dst, val),
-//         Relaxed => intrinsics::atomic_store_relaxed(dst, val),
-//         SeqCst => intrinsics::atomic_store(dst, val),
-//         Acquire => panic!("there is no such thing as an acquire store"),
-//         AcqRel => panic!("there is no such thing as an acquire/release store"),
-//     }
-// }
+#[inline]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_store<T>(dst: *mut T, val: T, order: Ordering) {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Release => intrinsics::atomic_store_rel(dst, val),
+        Relaxed => intrinsics::atomic_store_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_store(dst, val),
+        Acquire => panic!("there is no such thing as an acquire store"),
+        AcqRel => panic!("there is no such thing as an acquire/release store"),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        *dst = val;
+    }
+}
 
-// #[inline]
-// unsafe fn atomic_load<T>(dst: *const T, order: Ordering) -> T {
-//     match order {
-//         Acquire => intrinsics::atomic_load_acq(dst),
-//         Relaxed => intrinsics::atomic_load_relaxed(dst),
-//         SeqCst => intrinsics::atomic_load(dst),
-//         Release => panic!("there is no such thing as a release load"),
-//         AcqRel => panic!("there is no such thing as an acquire/release load"),
-//     }
-// }
+#[inline]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_load<T>(dst: *const T, order: Ordering) -> T
+           where T: Copy, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_load_acq(dst),
+        Relaxed => intrinsics::atomic_load_relaxed(dst),
+        SeqCst => intrinsics::atomic_load(dst),
+        Release => panic!("there is no such thing as a release load"),
+        AcqRel => panic!("there is no such thing as an acquire/release load"),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        *dst
+    }
+}
 
-// #[inline]
-// // #[cfg(target_has_atomic = "cas")]
-// unsafe fn atomic_swap<T>(dst: *mut T, val: T, order: Ordering) -> T {
-//     match order {
-//         Acquire => intrinsics::atomic_xchg_acq(dst, val),
-//         Release => intrinsics::atomic_xchg_rel(dst, val),
-//         AcqRel => intrinsics::atomic_xchg_acqrel(dst, val),
-//         Relaxed => intrinsics::atomic_xchg_relaxed(dst, val),
-//         SeqCst => intrinsics::atomic_xchg(dst, val),
-//     }
-// }
+#[inline]
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_swap<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_xchg_acq(dst, val),
+        Release => intrinsics::atomic_xchg_rel(dst, val),
+        AcqRel => intrinsics::atomic_xchg_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_xchg_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_xchg(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        let old = *dst;
+        *dst = val;
+        old
+    }
+}
 
-// /// Returns the previous value (like __sync_fetch_and_add).
-// #[inline]
-// // #[cfg(target_has_atomic = "cas")]
-// unsafe fn atomic_add<T>(dst: *mut T, val: T, order: Ordering) -> T {
-//     match order {
-//         Acquire => intrinsics::atomic_xadd_acq(dst, val),
-//         Release => intrinsics::atomic_xadd_rel(dst, val),
-//         AcqRel => intrinsics::atomic_xadd_acqrel(dst, val),
-//         Relaxed => intrinsics::atomic_xadd_relaxed(dst, val),
-//         SeqCst => intrinsics::atomic_xadd(dst, val),
-//     }
-// }
+/// Returns the previous value (like __sync_fetch_and_add).
+#[inline]
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
 
-// /// Returns the previous value (like __sync_fetch_and_sub).
-// #[inline]
-// // #[cfg(target_has_atomic = "cas")]
-// unsafe fn atomic_sub<T>(dst: *mut T, val: T, order: Ordering) -> T {
-//     match order {
-//         Acquire => intrinsics::atomic_xsub_acq(dst, val),
-//         Release => intrinsics::atomic_xsub_rel(dst, val),
-//         AcqRel => intrinsics::atomic_xsub_acqrel(dst, val),
-//         Relaxed => intrinsics::atomic_xsub_relaxed(dst, val),
-//         SeqCst => intrinsics::atomic_xsub(dst, val),
-//     }
-// }
+unsafe fn atomic_add<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::ops::Add<Output = T>, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_xadd_acq(dst, val),
+        Release => intrinsics::atomic_xadd_rel(dst, val),
+        AcqRel => intrinsics::atomic_xadd_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_xadd_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_xadd(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        let old = *dst;
+        *dst = old + val;
+        old
+    }
+}
 
-// #[inline]
-// // #[cfg(target_has_atomic = "cas")]
-// unsafe fn atomic_compare_exchange<T>(dst: *mut T,
-//                                      old: T,
-//                                      new: T,
-//                                      success: Ordering,
-//                                      failure: Ordering)
-//                                      -> Result<T, T> {
-//     let (val, ok) = match (success, failure) {
-//         (Acquire, Acquire) => intrinsics::atomic_cxchg_acq(dst, old, new),
-//         (Release, Relaxed) => intrinsics::atomic_cxchg_rel(dst, old, new),
-//         (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel(dst, old, new),
-//         (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed(dst, old, new),
-//         (SeqCst, SeqCst) => intrinsics::atomic_cxchg(dst, old, new),
-//         (Acquire, Relaxed) => intrinsics::atomic_cxchg_acq_failrelaxed(dst, old, new),
-//         (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_failrelaxed(dst, old, new),
-//         (SeqCst, Relaxed) => intrinsics::atomic_cxchg_failrelaxed(dst, old, new),
-//         (SeqCst, Acquire) => intrinsics::atomic_cxchg_failacq(dst, old, new),
-//         (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
-//         (_, Release) => panic!("there is no such thing as a release failure ordering"),
-//         _ => panic!("a failure ordering can't be stronger than a success ordering"),
-//     };
-//     if ok { Ok(val) } else { Err(val) }
-// }
+/// Returns the previous value (like __sync_fetch_and_sub).
+#[inline]
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_sub<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::ops::Sub<Output = T>, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_xsub_acq(dst, val),
+        Release => intrinsics::atomic_xsub_rel(dst, val),
+        AcqRel => intrinsics::atomic_xsub_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_xsub_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_xsub(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        let old = *dst;
+        *dst = old - val;
+        old
+    }
+}
 
-// #[inline]
-// // #[cfg(target_has_atomic = "cas")]
-// unsafe fn atomic_compare_exchange_weak<T>(dst: *mut T,
-//                                           old: T,
-//                                           new: T,
-//                                           success: Ordering,
-//                                           failure: Ordering)
-//                                           -> Result<T, T> {
-//     let (val, ok) = match (success, failure) {
-//         (Acquire, Acquire) => intrinsics::atomic_cxchgweak_acq(dst, old, new),
-//         (Release, Relaxed) => intrinsics::atomic_cxchgweak_rel(dst, old, new),
-//         (AcqRel, Acquire) => intrinsics::atomic_cxchgweak_acqrel(dst, old, new),
-//         (Relaxed, Relaxed) => intrinsics::atomic_cxchgweak_relaxed(dst, old, new),
-//         (SeqCst, SeqCst) => intrinsics::atomic_cxchgweak(dst, old, new),
-//         (Acquire, Relaxed) => intrinsics::atomic_cxchgweak_acq_failrelaxed(dst, old, new),
-//         (AcqRel, Relaxed) => intrinsics::atomic_cxchgweak_acqrel_failrelaxed(dst, old, new),
-//         (SeqCst, Relaxed) => intrinsics::atomic_cxchgweak_failrelaxed(dst, old, new),
-//         (SeqCst, Acquire) => intrinsics::atomic_cxchgweak_failacq(dst, old, new),
-//         (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
-//         (_, Release) => panic!("there is no such thing as a release failure ordering"),
-//         _ => panic!("a failure ordering can't be stronger than a success ordering"),
-//     };
-//     if ok { Ok(val) } else { Err(val) }
-// }
+#[inline]
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_compare_exchange<T>(dst: *mut T,
+                                     old: T,
+                                     new: T,
+                                     success: Ordering,
+                                     failure: Ordering)
+                                     -> Result<T, T>
+           where T: Copy + crate::cmp::PartialEq, {
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        let (val, ok) = match (success, failure) {
+            (Acquire, Acquire) => intrinsics::atomic_cxchg_acq(dst, old, new),
+            (Release, Relaxed) => intrinsics::atomic_cxchg_rel(dst, old, new),
+            (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel(dst, old, new),
+            (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed(dst, old, new),
+            (SeqCst, SeqCst) => intrinsics::atomic_cxchg(dst, old, new),
+            (Acquire, Relaxed) => intrinsics::atomic_cxchg_acq_failrelaxed(dst, old, new),
+            (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_failrelaxed(dst, old, new),
+            (SeqCst, Relaxed) => intrinsics::atomic_cxchg_failrelaxed(dst, old, new),
+            (SeqCst, Acquire) => intrinsics::atomic_cxchg_failacq(dst, old, new),
+            (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
+            (_, Release) => panic!("there is no such thing as a release failure ordering"),
+            _ => panic!("a failure ordering can't be stronger than a success ordering"),
+        };
+        if ok { Ok(val) } else { Err(val) }
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        let current = *dst;
+        if current == old {
+            *dst = new;
+            Ok(current)
+        } else {
+            Err(current)
+        }
+    }
+}
+
+#[inline]
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_compare_exchange_weak<T>(dst: *mut T,
+                                          old: T,
+                                          new: T,
+                                          success: Ordering,
+                                          failure: Ordering)
+                                          -> Result<T, T>
+           where T: Copy + crate::cmp::PartialEq, {
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        let (val, ok) = match (success, failure) {
+            (Acquire, Acquire) => intrinsics::atomic_cxchgweak_acq(dst, old, new),
+            (Release, Relaxed) => intrinsics::atomic_cxchgweak_rel(dst, old, new),
+            (AcqRel, Acquire) => intrinsics::atomic_cxchgweak_acqrel(dst, old, new),
+            (Relaxed, Relaxed) => intrinsics::atomic_cxchgweak_relaxed(dst, old, new),
+            (SeqCst, SeqCst) => intrinsics::atomic_cxchgweak(dst, old, new),
+            (Acquire, Relaxed) => intrinsics::atomic_cxchgweak_acq_failrelaxed(dst, old, new),
+            (AcqRel, Relaxed) => intrinsics::atomic_cxchgweak_acqrel_failrelaxed(dst, old, new),
+            (SeqCst, Relaxed) => intrinsics::atomic_cxchgweak_failrelaxed(dst, old, new),
+            (SeqCst, Acquire) => intrinsics::atomic_cxchgweak_failacq(dst, old, new),
+            (_, AcqRel) => panic!("there is no such thing as an acquire/release failure ordering"),
+            (_, Release) => panic!("there is no such thing as a release failure ordering"),
+            _ => panic!("a failure ordering can't be stronger than a success ordering"),
+        };
+        if ok { Ok(val) } else { Err(val) }
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        let current = *dst;
+        if current == old {
+            *dst = new;
+            Ok(current)
+        } else {
+            Err(current)
+        }
+    }
+}
 
 #[inline]
 #[cfg(target_has_atomic = "cas")]
@@ -2288,58 +2337,82 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
 
 /// returns the max value (signed comparison)
 #[inline]
-// #[cfg(target_has_atomic = "cas")]
-unsafe fn atomic_max<T>(_dst: *mut T, val: T, _order: Ordering) -> T {
-    // match order {
-    //     Acquire => intrinsics::atomic_max_acq(dst, val),
-    //     Release => intrinsics::atomic_max_rel(dst, val),
-    //     AcqRel => intrinsics::atomic_max_acqrel(dst, val),
-    //     Relaxed => intrinsics::atomic_max_relaxed(dst, val),
-    //     SeqCst => intrinsics::atomic_max(dst, val),
-    // }
-    val
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_max<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::cmp::Ord, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_max_acq(dst, val),
+        Release => intrinsics::atomic_max_rel(dst, val),
+        AcqRel => intrinsics::atomic_max_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_max_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_max(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        crate::cmp::max(*dst, val)
+    }
 }
 
 /// returns the min value (signed comparison)
 #[inline]
-// #[cfg(target_has_atomic = "cas")]
-unsafe fn atomic_min<T>(_dst: *mut T, val: T, _order: Ordering) -> T {
-    // match order {
-    //     Acquire => intrinsics::atomic_min_acq(dst, val),
-    //     Release => intrinsics::atomic_min_rel(dst, val),
-    //     AcqRel => intrinsics::atomic_min_acqrel(dst, val),
-    //     Relaxed => intrinsics::atomic_min_relaxed(dst, val),
-    //     SeqCst => intrinsics::atomic_min(dst, val),
-    // }
-    val
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_min<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::cmp::Ord, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_min_acq(dst, val),
+        Release => intrinsics::atomic_min_rel(dst, val),
+        AcqRel => intrinsics::atomic_min_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_min_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_min(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        crate::cmp::min(*dst, val)
+    }
 }
 
 /// returns the max value (signed comparison)
 #[inline]
-// #[cfg(target_has_atomic = "cas")]
-unsafe fn atomic_umax<T>(_dst: *mut T, val: T, _order: Ordering) -> T {
-    // match order {
-    //     Acquire => intrinsics::atomic_umax_acq(dst, val),
-    //     Release => intrinsics::atomic_umax_rel(dst, val),
-    //     AcqRel => intrinsics::atomic_umax_acqrel(dst, val),
-    //     Relaxed => intrinsics::atomic_umax_relaxed(dst, val),
-    //     SeqCst => intrinsics::atomic_umax(dst, val),
-    // }
-    val
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_umax<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::cmp::Ord, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_umax_acq(dst, val),
+        Release => intrinsics::atomic_umax_rel(dst, val),
+        AcqRel => intrinsics::atomic_umax_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_umax_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_umax(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        crate::cmp::max(*dst, val)
+    }
 }
 
 /// returns the min value (signed comparison)
 #[inline]
-// #[cfg(target_has_atomic = "cas")]
-unsafe fn atomic_umin<T>(_dst: *mut T, val: T, _order: Ordering) -> T {
-    // match order {
-    //     Acquire => intrinsics::atomic_umin_acq(dst, val),
-    //     Release => intrinsics::atomic_umin_rel(dst, val),
-    //     AcqRel => intrinsics::atomic_umin_acqrel(dst, val),
-    //     Relaxed => intrinsics::atomic_umin_relaxed(dst, val),
-    //     SeqCst => intrinsics::atomic_umin(dst, val),
-    // }
-    val
+#[cfg(target_has_atomic = "cas")]
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+unsafe fn atomic_umin<T>(dst: *mut T, val: T, order: Ordering) -> T
+           where T: Copy + crate::cmp::Ord, {
+    #[cfg(not(target_arch = "bpf"))]
+    match order {
+        Acquire => intrinsics::atomic_umin_acq(dst, val),
+        Release => intrinsics::atomic_umin_rel(dst, val),
+        AcqRel => intrinsics::atomic_umin_acqrel(dst, val),
+        Relaxed => intrinsics::atomic_umin_relaxed(dst, val),
+        SeqCst => intrinsics::atomic_umin(dst, val),
+    }
+    #[cfg(target_arch = "bpf")]
+    {
+        crate::cmp::min(*dst, val)
+    }
 }
 
 /// An atomic fence.
@@ -2420,24 +2493,24 @@ unsafe fn atomic_umin<T>(_dst: *mut T, val: T, _order: Ordering) -> T {
 /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-pub fn fence(_order: Ordering) {
-    // // On wasm32 it looks like fences aren't implemented in LLVM yet in that
-    // // they will cause LLVM to abort. The wasm instruction set doesn't have
-    // // fences right now. There's discussion online about the best way for tools
-    // // to conventionally implement fences at
-    // // https://github.com/WebAssembly/tool-conventions/issues/59. We should
-    // // follow that discussion and implement a solution when one comes about!
-    // #[cfg(not(target_arch = "wasm32"))]
-    // unsafe {
-    //     match order {
-    //         Acquire => intrinsics::atomic_fence_acq(),
-    //         Release => intrinsics::atomic_fence_rel(),
-    //         AcqRel => intrinsics::atomic_fence_acqrel(),
-    //         SeqCst => intrinsics::atomic_fence(),
-    //         Relaxed => panic!("there is no such thing as a relaxed fence"),
-    //     }
-    // }
+#[cfg_attr(any(target_arch = "wasm32", target_arch = "bpf"), allow(unused_variables))]
+pub fn fence(order: Ordering) {
+    // On wasm32 and BPF it looks like fences aren't implemented in LLVM yet in that
+    // they will cause LLVM to abort. The wasm instruction set doesn't have
+    // fences right now. There's discussion online about the best way for tools
+    // to conventionally implement fences at
+    // https://github.com/WebAssembly/tool-conventions/issues/59. We should
+    // follow that discussion and implement a solution when one comes about!
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "bpf")))]
+    unsafe {
+        match order {
+            Acquire => intrinsics::atomic_fence_acq(),
+            Release => intrinsics::atomic_fence_rel(),
+            AcqRel => intrinsics::atomic_fence_acqrel(),
+            SeqCst => intrinsics::atomic_fence(),
+            Relaxed => panic!("there is no such thing as a relaxed fence"),
+        }
+    }
 }
 
 
@@ -2516,16 +2589,18 @@ pub fn fence(_order: Ordering) {
 /// [memory barriers]: https://www.kernel.org/doc/Documentation/memory-barriers.txt
 #[inline]
 #[stable(feature = "compiler_fences", since = "1.21.0")]
-pub fn compiler_fence(_order: Ordering) {
-    // unsafe {
-    //     match order {
-    //         Acquire => intrinsics::atomic_singlethreadfence_acq(),
-    //         Release => intrinsics::atomic_singlethreadfence_rel(),
-    //         AcqRel => intrinsics::atomic_singlethreadfence_acqrel(),
-    //         SeqCst => intrinsics::atomic_singlethreadfence(),
-    //         Relaxed => panic!("there is no such thing as a relaxed compiler fence"),
-    //     }
-    // }
+#[cfg_attr(target_arch = "bpf", allow(unused_variables))]
+pub fn compiler_fence(order: Ordering) {
+    #[cfg(not(target_arch = "bpf"))]
+    unsafe {
+        match order {
+            Acquire => intrinsics::atomic_singlethreadfence_acq(),
+            Release => intrinsics::atomic_singlethreadfence_rel(),
+            AcqRel => intrinsics::atomic_singlethreadfence_acqrel(),
+            SeqCst => intrinsics::atomic_singlethreadfence(),
+            Relaxed => panic!("there is no such thing as a relaxed compiler fence"),
+        }
+    }
 }
 
 
@@ -2537,7 +2612,7 @@ impl fmt::Debug for AtomicBool {
     }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "atomic_debug", since = "1.3.0")]
 impl<T> fmt::Debug for AtomicPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2545,7 +2620,7 @@ impl<T> fmt::Debug for AtomicPtr<T> {
     }
 }
 
-// #[cfg(target_has_atomic = "ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "atomic_pointer", since = "1.24.0")]
 impl<T> fmt::Pointer for AtomicPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -13,6 +13,9 @@ name = "std"
 path = "lib.rs"
 # crate-type = ["dylib", "rlib"]
 
+[workspace]
+members = []
+
 [dependencies]
 alloc = { path = "../liballoc" }
 # panic_unwind = { path = "../libpanic_unwind", optional = true }
@@ -25,9 +28,6 @@ compiler_builtins = { path = "../compiler-builtins" }
 hashbrown = { path = "../../../hashbrown", features = ['rustc-dep-of-std'] }
 # rustc-demangle = { version = "0.1.10", features = ['rustc-dep-of-std'] }
 # backtrace-sys = { version = "0.1.24", features = ["rustc-dep-of-std"], optional = true }
-
-[workspace]
-members = []
 
 [dev-dependencies]
 # rand = "0.6.1"

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -331,10 +331,11 @@ extern crate alloc as alloc_crate;
 #[allow(unused_extern_crates)]
 extern crate libc;
 
-// // We always need an unwinder currently for backtraces
-// #[doc(masked)]
-// #[allow(unused_extern_crates)]
-// extern crate unwind;
+// We always need an unwinder currently for backtraces
+#[doc(masked)]
+#[allow(unused_extern_crates)]
+#[cfg(not(target_arch = "bpf"))]
+extern crate unwind;
 
 // During testing, this crate is not actually the "real" std library, but rather
 // it links to the real std library, which was compiled from this same source
@@ -485,22 +486,24 @@ mod memchr;
 // compiler
 pub mod rt;
 
-// // Pull in the `std_detect` crate directly into libstd. The contents of
-// // `std_detect` are in a different repository: rust-lang-nursery/stdsimd.
-// //
-// // `std_detect` depends on libstd, but the contents of this module are
-// // set up in such a way that directly pulling it here works such that the
-// // crate uses the this crate as its libstd.
-// #[path = "../stdsimd/crates/std_detect/src/mod.rs"]
-// #[allow(missing_debug_implementations, missing_docs, dead_code)]
-// #[unstable(feature = "stdsimd", issue = "48556")]
-// #[cfg(not(test))]
-// mod std_detect;
+// Pull in the `std_detect` crate directly into libstd. The contents of
+// `std_detect` are in a different repository: rust-lang-nursery/stdsimd.
+//
+// `std_detect` depends on libstd, but the contents of this module are
+// set up in such a way that directly pulling it here works such that the
+// crate uses the this crate as its libstd.
+#[path = "../stdsimd/crates/std_detect/src/mod.rs"]
+#[allow(missing_debug_implementations, missing_docs, dead_code)]
+#[unstable(feature = "stdsimd", issue = "48556")]
+#[cfg(not(test))]
+#[cfg(not(target_arch = "bpf"))]
+mod std_detect;
 
-// #[doc(hidden)]
-// #[unstable(feature = "stdsimd", issue = "48556")]
-// #[cfg(not(test))]
-// pub use std_detect::detect;
+#[doc(hidden)]
+#[unstable(feature = "stdsimd", issue = "48556")]
+#[cfg(not(test))]
+#[cfg(not(target_arch = "bpf"))]
+pub use std_detect::detect;
 
 // Include a number of private modules that exist solely to provide
 // the rustdoc documentation for primitive types. Using `include!`

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -261,7 +261,7 @@
 #![feature(exhaustive_patterns)]
 #![feature(external_doc)]
 #![feature(fn_traits)]
-// #![feature(fnbox)]
+#![feature(fnbox)]
 #![feature(generator_trait)]
 #![feature(hash_raw_entry)]
 #![feature(hashmap_internals)]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -59,13 +59,20 @@ macro_rules! panic {
         panic!("explicit panic")
     });
     ($msg:expr) => ({
-        $crate::rt::begin_panic($msg, file!(), line!(), __rust_unstable_column!())
+
+        $crate::rt::begin_panic(&(file!(), line!(), __rust_unstable_column!()))
     });
     ($msg:expr,) => ({
         panic!($msg)
     });
     ($fmt:expr, $($arg:tt)+) => ({
-        $crate::rt::begin_panic("explicit panic", file!(), line!(), __rust_unstable_column!())
+        if false {
+            $crate::rt::begin_panic_fmt(&format_args!($fmt, $($arg)+),
+                                        &(file!(), line!(), __rust_unstable_column!()))
+        } else {
+            // Calling `format_args` bloats the final BPF ELF by ~40k, don't do it
+            $crate::rt::begin_panic(&(file!(), line!(), __rust_unstable_column!()))
+        }
     });
 }
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -59,14 +59,13 @@ macro_rules! panic {
         panic!("explicit panic")
     });
     ($msg:expr) => ({
-        $crate::rt::begin_panic($msg, &(file!(), line!(), __rust_unstable_column!()))
+        $crate::rt::begin_panic($msg, file!(), line!(), __rust_unstable_column!())
     });
     ($msg:expr,) => ({
         panic!($msg)
     });
     ($fmt:expr, $($arg:tt)+) => ({
-        $crate::rt::begin_panic_fmt(&format_args!($fmt, $($arg)+),
-                                    &(file!(), line!(), __rust_unstable_column!()))
+        $crate::rt::begin_panic("explicit panic", file!(), line!(), __rust_unstable_column!())
     });
 }
 

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -17,8 +17,8 @@ cfg_if! {
         #[stable(feature = "rust1", since = "1.0.0")]
         pub use crate::sys::windows_ext as windows;
 
-        // #[doc(cfg(target_os = "linux"))]
-        // pub mod linux;
+        #[doc(cfg(target_os = "linux"))]
+        pub mod linux;
     } else {
 
         // If we're not documenting libstd then we just expose the main modules
@@ -32,8 +32,8 @@ cfg_if! {
         #[stable(feature = "rust1", since = "1.0.0")]
         pub use crate::sys::ext as windows;
 
-        // #[cfg(any(target_os = "linux", target_os = "l4re"))]
-        // pub mod linux;
+        #[cfg(any(target_os = "linux", target_os = "l4re"))]
+        pub mod linux;
 
     }
 }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -418,5 +418,7 @@ pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
 /// ```
 #[stable(feature = "resume_unwind", since = "1.9.0")]
 pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
-    panicking::update_count_then_panic(payload)
+    // Only used by thread, redirect to plain old panic
+    // panicking::update_count_then_panic(payload)
+    panicking::begin_panic("", file!(), line!(), 0)
 }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -7,26 +7,13 @@
 //! * Executing a panic up to doing the actual implementation
 //! * Shims around "try"
 
-use core::panic::{BoxMeUp, PanicInfo, Location};
+use core::panic::{PanicInfo, Location};
 
 use crate::any::Any;
 use crate::fmt;
-use crate::intrinsics;
 use crate::mem;
 use crate::ptr;
 use crate::raw;
-// use crate::sys::stdio::panic_output;
-// use crate::sys_common::rwlock::RWLock;
-use crate::sys_common::thread_info;
-// use crate::sys_common::util;
-// use crate::thread;
-
-// #[cfg(not(test))]
-// use crate::io::set_panic;
-// // make sure to use the stderr output configured
-// // by libtest in the real copy of std
-// #[cfg(test)]
-// use realstd::io::set_panic;
 
 // Binary interface to the panic runtime that the standard library depends on.
 //
@@ -44,18 +31,7 @@ extern {
                                 data: *mut u8,
                                 data_ptr: *mut usize,
                                 vtable_ptr: *mut usize) -> u32;
-    #[unwind(allowed)]
-    fn __rust_start_panic(payload: usize) -> u32;
 }
-
-// #[derive(Copy, Clone)]
-// enum Hook {
-//     Default,
-//     Custom(*mut (dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send)),
-// }
-
-// static HOOK_LOCK: RWLock = RWLock::new();
-// static mut HOOK: Hook = Hook::Default;
 
 /// Registers a custom panic hook, replacing any that was previously registered.
 ///
@@ -92,20 +68,6 @@ extern {
 /// ```
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub fn set_hook(_hook: Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>) {
-    // if thread::panicking() {
-    //     panic!("cannot modify the panic hook from a panicking thread");
-    // }
-
-    // unsafe {
-    //     HOOK_LOCK.write();
-    //     let old_hook = HOOK;
-    //     HOOK = Hook::Custom(Box::into_raw(hook));
-    //     HOOK_LOCK.write_unlock();
-
-    //     if let Hook::Custom(ptr) = old_hook {
-    //         Box::from_raw(ptr);
-    //     }
-    // }
 }
 
 /// Unregisters the current panic hook, returning it.
@@ -137,100 +99,23 @@ pub fn set_hook(_hook: Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>) {
 /// ```
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub fn take_hook() -> Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send> {
-    // if thread::panicking() {
-    //     panic!("cannot modify the panic hook from a panicking thread");
-    // }
-
-    // unsafe {
-    //     HOOK_LOCK.write();
-    //     let hook = HOOK;
-    //     HOOK = Hook::Default;
-    //     HOOK_LOCK.write_unlock();
-
-    //     match hook {
-    //         Hook::Default => Box::new(default_hook),
-    //         Hook::Custom(ptr) => Box::from_raw(ptr),
-    //     }
-    // }
-
     Box::new(default_hook)
 }
 
 fn default_hook(info: &PanicInfo<'_>) {
-    #[cfg(feature = "backtrace")]
-    use crate::sys_common::backtrace;
-
-    // If this is a double panic, make sure that we print a backtrace
-    // for this panic. Otherwise only print it if logging is enabled.
-    #[cfg(feature = "backtrace")]
-    let log_backtrace = {
-        let panics = update_panic_count(0);
-
-        if panics >= 2 {
-            Some(backtrace::PrintFormat::Full)
-        } else {
-            backtrace::log_enabled()
-        }
-    };
-
-    let location = info.location().unwrap();  // The current implementation always returns Some
-
-    let msg = match info.payload().downcast_ref::<&'static str>() {
-        Some(s) => *s,
-        None => match info.payload().downcast_ref::<String>() {
-            Some(s) => &s[..],
-            None => "Box<Any>",
-        }
-    };
-    let thread = thread_info::current_thread();
-    let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");
-
-    let _write = |err: &mut dyn crate::io::Write| {
-        let _ = writeln!(err, "thread '{}' panicked at '{}', {}",
-                         name, msg, location);
-
-        #[cfg(feature = "backtrace")]
-        {
-            use crate::sync::atomic::{AtomicBool, Ordering};
-
-            static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
-
-            if let Some(format) = log_backtrace {
-                let _ = backtrace::print(err, format);
-            } else if FIRST_PANIC.compare_and_swap(true, false, Ordering::SeqCst) {
-                let _ = writeln!(err, "note: Run with `RUST_BACKTRACE=1` \
-                                       environment variable to display a backtrace.");
-            }
-        }
-    };
-
-    // if let Some(mut local) = set_panic(None) {
-    //     // NB. In `cfg(test)` this uses the forwarding impl
-    //     // for `Box<dyn (::realstd::io::Write) + Send>`.
-    //     write(&mut local);
-    //     set_panic(Some(local));
-    // } else if let Some(mut out) = panic_output() {
-    //     write(&mut out);
-    // }
+    crate::sys::sol_log("default_hook");
+    crate::sys::panic(info);
 }
-
 
 #[cfg(not(test))]
 #[doc(hidden)]
 #[unstable(feature = "update_panic_count", issue = "0")]
-pub fn update_panic_count(amt: isize) -> usize {
-    use crate::cell::Cell;
-    thread_local! { static PANIC_COUNT: Cell<usize> = Cell::new(0) }
-
-    PANIC_COUNT.with(|c| {
-        let next = (c.get() as isize + amt) as usize;
-        c.set(next);
-        return next
-    })
+pub fn update_panic_count(_amt: isize) -> usize {
+    1
 }
 
-#[cfg(test)]
-pub use realstd::rt::update_panic_count;
+// #[cfg(test)]
+// pub use realstd::rt::;
 
 /// Invoke a closure, capturing the cause of an unwinding panic if one occurs.
 pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
@@ -277,11 +162,11 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
                                      &mut any_vtable);
 
     return if r == 0 {
-        debug_assert!(update_panic_count(0) == 0);
+        // debug_assert!(update_panic_count(0) == 0);
         Ok(data.r)
     } else {
-        update_panic_count(-1);
-        debug_assert!(update_panic_count(0) == 0);
+        // update_panic_count(-1);
+        // debug_assert!(update_panic_count(0) == 0);
         Err(mem::transmute(raw::TraitObject {
             data: any_data as *mut _,
             vtable: any_vtable as *mut _,
@@ -297,9 +182,9 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     }
 }
 
-/// Determines whether the current thread is unwinding because of panic.
+// /// Determines whether the current thread is unwinding because of panic.
 pub fn panicking() -> bool {
-    update_panic_count(0) != 0
+    true
 }
 
 /// Entry point of panic from the libcore crate.
@@ -307,83 +192,8 @@ pub fn panicking() -> bool {
 #[panic_handler]
 #[unwind(allowed)]
 pub fn rust_begin_panic(info: &PanicInfo<'_>) -> ! {
+    crate::sys::sol_log("rust_begin_panic");
     crate::sys::panic(info);
-}
-
-/// The entry point for panicking with a formatted message.
-///
-/// This is designed to reduce the amount of code required at the call
-/// site as much as possible (so that `panic!()` has as low an impact
-/// on (e.g.) the inlining of other functions as possible), by moving
-/// the actual formatting into this shared place.
-#[unstable(feature = "libstd_sys_internals",
-           reason = "used by the panic! macro",
-           issue = "0")]
-#[cold]
-// If panic_immediate_abort, inline the abort call,
-// otherwise avoid inlining because of it is cold path.
-#[cfg_attr(not(feature="panic_immediate_abort"),inline(never))]
-#[cfg_attr(    feature="panic_immediate_abort" ,inline)]
-pub fn begin_panic_fmt(msg: &fmt::Arguments<'_>,
-                       file_line_col: &(&'static str, u32, u32)) -> ! {
-    if cfg!(feature = "panic_immediate_abort") {
-        unsafe { intrinsics::abort() }
-    }
-
-    let (file, line, col) = *file_line_col;
-    let info = PanicInfo::internal_constructor(
-        Some(msg),
-        Location::internal_constructor(file, line, col),
-    );
-    continue_panic_fmt(&info)
-}
-
-fn continue_panic_fmt(info: &PanicInfo<'_>) -> ! {
-    struct PanicPayload<'a> {
-        inner: &'a fmt::Arguments<'a>,
-        string: Option<String>,
-    }
-
-    impl<'a> PanicPayload<'a> {
-        fn new(inner: &'a fmt::Arguments<'a>) -> PanicPayload<'a> {
-            PanicPayload { inner, string: None }
-        }
-
-        fn fill(&mut self) -> &mut String {
-            use crate::fmt::Write;
-
-            let inner = self.inner;
-            self.string.get_or_insert_with(|| {
-                let mut s = String::new();
-                drop(s.write_fmt(*inner));
-                s
-            })
-        }
-    }
-
-    unsafe impl<'a> BoxMeUp for PanicPayload<'a> {
-        fn box_me_up(&mut self) -> *mut (dyn Any + Send) {
-            let contents = mem::replace(self.fill(), String::new());
-            Box::into_raw(Box::new(contents))
-        }
-
-        fn get(&mut self) -> &(dyn Any + Send) {
-            self.fill()
-        }
-    }
-
-    // We do two allocations here, unfortunately. But (a) they're
-    // required with the current scheme, and (b) we don't handle
-    // panic + OOM properly anyway (see comment in begin_panic
-    // below).
-
-    let loc = info.location().unwrap(); // The current implementation always returns Some
-    let msg = info.message().unwrap(); // The current implementation always returns Some
-    let file_line_col = (loc.file(), loc.line(), loc.column());
-    rust_panic_with_hook(
-        &mut PanicPayload::new(msg),
-        info.message(),
-        &file_line_col);
 }
 
 /// This is the entry point of panicking for panic!() and assert!().
@@ -395,135 +205,10 @@ fn continue_panic_fmt(info: &PanicInfo<'_>) -> ! {
 // bloat at the call sites as much as possible
 #[cfg_attr(not(feature="panic_immediate_abort"),inline(never))]
 #[cold]
-pub fn begin_panic<M: Any + Send>(msg: M, file_line_col: &(&'static str, u32, u32)) -> ! {
-    if cfg!(feature = "panic_immediate_abort") {
-        unsafe { intrinsics::abort() }
-    }
-
-    // Note that this should be the only allocation performed in this code path.
-    // Currently this means that panic!() on OOM will invoke this code path,
-    // but then again we're not really ready for panic on OOM anyway. If
-    // we do start doing this, then we should propagate this allocation to
-    // be performed in the parent of this thread instead of the thread that's
-    // panicking.
-
-    rust_panic_with_hook(&mut PanicPayload::new(msg), None, file_line_col);
-
-    struct PanicPayload<A> {
-        inner: Option<A>,
-    }
-
-    impl<A: Send + 'static> PanicPayload<A> {
-        fn new(inner: A) -> PanicPayload<A> {
-            PanicPayload { inner: Some(inner) }
-        }
-    }
-
-    unsafe impl<A: Send + 'static> BoxMeUp for PanicPayload<A> {
-        fn box_me_up(&mut self) -> *mut (dyn Any + Send) {
-            let data = match self.inner.take() {
-                Some(a) => Box::new(a) as Box<dyn Any + Send>,
-                None => Box::new(()),
-            };
-            Box::into_raw(data)
-        }
-
-        fn get(&mut self) -> &(dyn Any + Send) {
-            match self.inner {
-                Some(ref a) => a,
-                None => &(),
-            }
-        }
-    }
-}
-
-/// Central point for dispatching panics.
-///
-/// Executes the primary logic for a panic, including checking for recursive
-/// panics, panic hooks, and finally dispatching to the panic runtime to either
-/// abort or unwind.
-fn rust_panic_with_hook(payload: &mut dyn BoxMeUp,
-                        _message: Option<&fmt::Arguments<'_>>,
-                        _file_line_col: &(&str, u32, u32)) -> ! {
-    // Skip panic counting  and hooks, don't use or need them
-    // let (file, line, col) = *file_line_col;
-
-    // let panics = update_panic_count(1);
-
-    // // If this is the third nested call (e.g., panics == 2, this is 0-indexed),
-    // // the panic hook probably triggered the last panic, otherwise the
-    // // double-panic check would have aborted the process. In this case abort the
-    // // process real quickly as we don't want to try calling it again as it'll
-    // // probably just panic again.
-    // if panics > 2 {
-    //     util::dumb_print(format_args!("thread panicked while processing \
-    //                                    panic. aborting.\n"));
-    //     unsafe { intrinsics::abort() }
-    // }
-
-    // unsafe {
-    //     let mut info = PanicInfo::internal_constructor(
-    //         message,
-    //         Location::internal_constructor(file, line, col),
-    //     );
-    //     HOOK_LOCK.read();
-    //     match HOOK {
-    //         // Some platforms know that printing to stderr won't ever actually
-    //         // print anything, and if that's the case we can skip the default
-    //         // hook.
-    //         Hook::Default if panic_output().is_none() => {}
-    //         Hook::Default => {
-    //             info.set_payload(payload.get());
-    //             default_hook(&info);
-    //         }
-    //         Hook::Custom(ptr) => {
-    //             info.set_payload(payload.get());
-    //             (*ptr)(&info);
-    //         }
-    //     };
-    //     HOOK_LOCK.read_unlock();
-    // }
-
-    // if panics > 1 {
-    //     // If a thread panics while it's already unwinding then we
-    //     // have limited options. Currently our preference is to
-    //     // just abort. In the future we may consider resuming
-    //     // unwinding or otherwise exiting the thread cleanly.
-    //     util::dumb_print(format_args!("thread panicked while panicking. \
-    //                                    aborting.\n"));
-    //     unsafe { intrinsics::abort() }
-    // }
-
-    rust_panic(payload)
-}
-
-/// Shim around rust_panic. Called by resume_unwind.
-pub fn update_count_then_panic(msg: Box<dyn Any + Send>) -> ! {
-    update_panic_count(1);
-
-    struct RewrapBox(Box<dyn Any + Send>);
-
-    unsafe impl BoxMeUp for RewrapBox {
-        fn box_me_up(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(mem::replace(&mut self.0, Box::new(())))
-        }
-
-        fn get(&mut self) -> &(dyn Any + Send) {
-            &*self.0
-        }
-    }
-
-    rust_panic(&mut RewrapBox(msg))
-}
-
-/// An unmangled function (through `rustc_std_internal_symbol`) on which to slap
-/// yer breakpoints.
-#[inline(never)]
-#[cfg_attr(not(test), rustc_std_internal_symbol)]
-fn rust_panic(mut msg: &mut dyn BoxMeUp) -> ! {
-    let code = unsafe {
-        let obj = &mut msg as *mut &mut dyn BoxMeUp;
-        __rust_start_panic(obj as usize)
-    };
-    rtabort!("failed to initiate panic, error {}", code)
+pub fn begin_panic<M: Any + Send>(_msg: M, file: &'static str, line: u32, column: u32) -> ! {
+    let info = PanicInfo::internal_constructor(
+        None,
+        Location::internal_constructor(file, line, column),
+    );
+    crate::sys::panic(&info);
 }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -7,182 +7,15 @@
 //! * Executing a panic up to doing the actual implementation
 //! * Shims around "try"
 
+// Note: The panicking functions have been stripped and rewritten 
+//       in order to same space in BPF programs.  Panic messages
+//       are not supported, just file, line, column
+
 use core::panic::{PanicInfo, Location};
 
-use crate::any::Any;
 use crate::fmt;
-use crate::mem;
-use crate::ptr;
-use crate::raw;
 
-// Binary interface to the panic runtime that the standard library depends on.
-//
-// The standard library is tagged with `#![needs_panic_runtime]` (introduced in
-// RFC 1513) to indicate that it requires some other crate tagged with
-// `#![panic_runtime]` to exist somewhere. Each panic runtime is intended to
-// implement these symbols (with the same signatures) so we can get matched up
-// to them.
-//
-// One day this may look a little less ad-hoc with the compiler helping out to
-// hook up these functions, but it is not this day!
-#[allow(improper_ctypes)]
-extern {
-    fn __rust_maybe_catch_panic(f: fn(*mut u8),
-                                data: *mut u8,
-                                data_ptr: *mut usize,
-                                vtable_ptr: *mut usize) -> u32;
-}
-
-/// Registers a custom panic hook, replacing any that was previously registered.
-///
-/// The panic hook is invoked when a thread panics, but before the panic runtime
-/// is invoked. As such, the hook will run with both the aborting and unwinding
-/// runtimes. The default hook prints a message to standard error and generates
-/// a backtrace if requested, but this behavior can be customized with the
-/// `set_hook` and [`take_hook`] functions.
-///
-/// [`take_hook`]: ./fn.take_hook.html
-///
-/// The hook is provided with a `PanicInfo` struct which contains information
-/// about the origin of the panic, including the payload passed to `panic!` and
-/// the source code location from which the panic originated.
-///
-/// The panic hook is a global resource.
-///
-/// # Panics
-///
-/// Panics if called from a panicking thread.
-///
-/// # Examples
-///
-/// The following will print "Custom panic hook":
-///
-/// ```should_panic
-/// use std::panic;
-///
-/// panic::set_hook(Box::new(|_| {
-///     println!("Custom panic hook");
-/// }));
-///
-/// panic!("Normal panic");
-/// ```
-#[stable(feature = "panic_hooks", since = "1.10.0")]
-pub fn set_hook(_hook: Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>) {
-}
-
-/// Unregisters the current panic hook, returning it.
-///
-/// *See also the function [`set_hook`].*
-///
-/// [`set_hook`]: ./fn.set_hook.html
-///
-/// If no custom hook is registered, the default hook will be returned.
-///
-/// # Panics
-///
-/// Panics if called from a panicking thread.
-///
-/// # Examples
-///
-/// The following will print "Normal panic":
-///
-/// ```should_panic
-/// use std::panic;
-///
-/// panic::set_hook(Box::new(|_| {
-///     println!("Custom panic hook");
-/// }));
-///
-/// let _ = panic::take_hook();
-///
-/// panic!("Normal panic");
-/// ```
-#[stable(feature = "panic_hooks", since = "1.10.0")]
-pub fn take_hook() -> Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send> {
-    Box::new(default_hook)
-}
-
-fn default_hook(info: &PanicInfo<'_>) {
-    crate::sys::sol_log("default_hook");
-    crate::sys::panic(info);
-}
-
-#[cfg(not(test))]
-#[doc(hidden)]
-#[unstable(feature = "update_panic_count", issue = "0")]
-pub fn update_panic_count(_amt: isize) -> usize {
-    1
-}
-
-// #[cfg(test)]
-// pub use realstd::rt::;
-
-/// Invoke a closure, capturing the cause of an unwinding panic if one occurs.
-pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
-    #[allow(unions_with_drop_fields)]
-    union Data<F, R> {
-        f: F,
-        r: R,
-    }
-
-    // We do some sketchy operations with ownership here for the sake of
-    // performance. We can only  pass pointers down to
-    // `__rust_maybe_catch_panic` (can't pass objects by value), so we do all
-    // the ownership tracking here manually using a union.
-    //
-    // We go through a transition where:
-    //
-    // * First, we set the data to be the closure that we're going to call.
-    // * When we make the function call, the `do_call` function below, we take
-    //   ownership of the function pointer. At this point the `Data` union is
-    //   entirely uninitialized.
-    // * If the closure successfully returns, we write the return value into the
-    //   data's return slot. Note that `ptr::write` is used as it's overwriting
-    //   uninitialized data.
-    // * Finally, when we come back out of the `__rust_maybe_catch_panic` we're
-    //   in one of two states:
-    //
-    //      1. The closure didn't panic, in which case the return value was
-    //         filled in. We move it out of `data` and return it.
-    //      2. The closure panicked, in which case the return value wasn't
-    //         filled in. In this case the entire `data` union is invalid, so
-    //         there is no need to drop anything.
-    //
-    // Once we stack all that together we should have the "most efficient'
-    // method of calling a catch panic whilst juggling ownership.
-    let mut any_data = 0;
-    let mut any_vtable = 0;
-    let mut data = Data {
-        f,
-    };
-
-    let r = __rust_maybe_catch_panic(do_call::<F, R>,
-                                     &mut data as *mut _ as *mut u8,
-                                     &mut any_data,
-                                     &mut any_vtable);
-
-    return if r == 0 {
-        // debug_assert!(update_panic_count(0) == 0);
-        Ok(data.r)
-    } else {
-        // update_panic_count(-1);
-        // debug_assert!(update_panic_count(0) == 0);
-        Err(mem::transmute(raw::TraitObject {
-            data: any_data as *mut _,
-            vtable: any_vtable as *mut _,
-        }))
-    };
-
-    fn do_call<F: FnOnce() -> R, R>(data: *mut u8) {
-        unsafe {
-            let data = data as *mut Data<F, R>;
-            let f = ptr::read(&mut (*data).f);
-            ptr::write(&mut (*data).r, f());
-        }
-    }
-}
-
-// /// Determines whether the current thread is unwinding because of panic.
+/// Determines whether the current thread is unwinding because of panic.
 pub fn panicking() -> bool {
     true
 }
@@ -192,11 +25,29 @@ pub fn panicking() -> bool {
 #[panic_handler]
 #[unwind(allowed)]
 pub fn rust_begin_panic(info: &PanicInfo<'_>) -> ! {
-    crate::sys::sol_log("rust_begin_panic");
     crate::sys::panic(info);
 }
 
-/// This is the entry point of panicking for panic!() and assert!().
+/// The entry point for panicking with a formatted message.
+///
+/// This is designed to reduce the amount of code required at the call
+/// site as much as possible (so that `panic!()` has as low an impact
+/// on (e.g.) the inlining of other functions as possible), by moving
+/// the actual formatting into this shared place.
+#[unstable(feature = "libstd_sys_internals",
+           reason = "used by the panic! macro",
+           issue = "0")]
+#[cold]
+// If panic_immediate_abort, inline the abort call,
+// otherwise avoid inlining because of it is cold path.
+#[cfg_attr(not(feature="panic_immediate_abort"),inline(never))]
+#[cfg_attr(    feature="panic_immediate_abort" ,inline)]
+pub fn begin_panic_fmt(_msg: &fmt::Arguments<'_>,
+                       file_line_col: &(&'static str, u32, u32)) -> ! {
+    begin_panic(file_line_col);
+}
+
+/// Entry point of panicking for panic!() and assert!().
 #[unstable(feature = "libstd_sys_internals",
            reason = "used by the panic! macro",
            issue = "0")]
@@ -205,10 +56,11 @@ pub fn rust_begin_panic(info: &PanicInfo<'_>) -> ! {
 // bloat at the call sites as much as possible
 #[cfg_attr(not(feature="panic_immediate_abort"),inline(never))]
 #[cold]
-pub fn begin_panic<M: Any + Send>(_msg: M, file: &'static str, line: u32, column: u32) -> ! {
+pub fn begin_panic(file_line_col: &(&'static str, u32, u32)) -> ! {
+    let (file, line, col) = *file_line_col;
     let info = PanicInfo::internal_constructor(
         None,
-        Location::internal_constructor(file, line, column),
+        Location::internal_constructor(file, line, col),
     );
     crate::sys::panic(&info);
 }

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -14,11 +14,14 @@
 
 
 // Re-export some of our utilities which are expected by other crates.
-pub use crate::panicking::{begin_panic};
+pub use crate::panicking::{begin_panic, begin_panic_fmt};
+#[cfg(not(target_arch = "bpf"))]
+pub use crate::panicking::update_panic_count;
 
 // To reduce the generated code of the new `lang_start`, this function is doing
 // the real work.
 #[cfg(not(test))]
+#[cfg(not(target_arch = "bpf"))]
 fn lang_start_internal(main: &(dyn Fn() -> i32 + Sync + crate::panic::RefUnwindSafe),
                        argc: isize, argv: *const *const u8) -> isize {
     use crate::panic;
@@ -57,6 +60,7 @@ fn lang_start_internal(main: &(dyn Fn() -> i32 + Sync + crate::panic::RefUnwindS
 }
 
 #[cfg(not(test))]
+#[cfg(not(target_arch = "bpf"))]
 #[lang = "start"]
 fn lang_start<T: crate::process::Termination + 'static>
     (main: fn() -> T, argc: isize, argv: *const *const u8) -> isize

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -14,7 +14,7 @@
 
 
 // Re-export some of our utilities which are expected by other crates.
-pub use crate::panicking::{begin_panic, begin_panic_fmt, update_panic_count};
+pub use crate::panicking::{begin_panic};
 
 // To reduce the generated code of the new `lang_start`, this function is doing
 // the real work.

--- a/src/libstd/sys/bpf/args.rs
+++ b/src/libstd/sys/bpf/args.rs
@@ -2,9 +2,9 @@ use crate::ffi::OsString;
 use crate::marker::PhantomData;
 use crate::vec;
 
-pub unsafe fn init(_argc: isize, _argv: *const *const u8) {
-    // On BPF these should always be null, so there's nothing for us to do here
-}
+// pub unsafe fn init(_argc: isize, _argv: *const *const u8) {
+//     // On BPF these should always be null, so there's nothing for us to do here
+// }
 
 pub unsafe fn cleanup() {
 }

--- a/src/libstd/sys/bpf/mod.rs
+++ b/src/libstd/sys/bpf/mod.rs
@@ -90,9 +90,9 @@ extern "C" {
     fn sol_panic_(file: *const u8, len: u64, line: u64, column: u64) -> !;
 }
 
-#[cfg(not(test))]
-pub fn init() {
-}
+// #[cfg(not(test))]
+// pub fn init() {
+// }
 
 pub fn unsupported<T>() -> crate::io::Result<T> {
     Err(unsupported_err())

--- a/src/libstd/sys/bpf/mod.rs
+++ b/src/libstd/sys/bpf/mod.rs
@@ -51,14 +51,15 @@ extern "C" {
     fn sol_log_(message: *const u8, length: u64);
 }
 
-// pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
-//     unsafe {
-//         sol_log_64_(arg1, arg2, arg3, arg4, arg5);
-//     }
-// }
-// extern "C" {
-//     fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
-// }
+#[allow(dead_code)]
+pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+    unsafe {
+        sol_log_64_(arg1, arg2, arg3, arg4, arg5);
+    }
+}
+extern "C" {
+    fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
+}
 
 pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     // Message is ignored for now to avoid incurring formatting overhead
@@ -80,14 +81,14 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
                 );
             }
         }
-        None => unsafe { sol_panic_(ptr::null(), 0, 0, 0) },
+        None => unsafe { 
+            sol_panic_(ptr::null(), 0, 0, 0)
+        },
     }
 }
 extern "C" {
     fn sol_panic_(file: *const u8, len: u64, line: u64, column: u64) -> !;
 }
-
-
 
 #[cfg(not(test))]
 pub fn init() {

--- a/src/libstd/sys/bpf/stack_overflow.rs
+++ b/src/libstd/sys/bpf/stack_overflow.rs
@@ -6,8 +6,5 @@ impl Handler {
     }
 }
 
-pub unsafe fn init() {
-}
-
 pub unsafe fn cleanup() {
 }

--- a/src/libstd/sys/bpf/thread.rs
+++ b/src/libstd/sys/bpf/thread.rs
@@ -35,5 +35,5 @@ impl Thread {
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> { None }
-    pub unsafe fn init() -> Option<Guard> { None }
+    // pub unsafe fn init() -> Option<Guard> { None }
 }

--- a/src/libstd/sys_common/at_exit_imp.rs
+++ b/src/libstd/sys_common/at_exit_imp.rs
@@ -3,7 +3,6 @@
 //! Documentation can be found on the `rt::at_exit` function.
 
 use crate::ptr;
-// use crate::mem;
 use crate::sys_common::mutex::Mutex;
 
 type Queue = Vec<Box<dyn FnOnce()>>;
@@ -23,7 +22,8 @@ const DONE: *mut Queue = 1_usize as *mut _;
 // the at_exit closures new ones may be registered, and this count is the number
 // of times the new closures will be allowed to register successfully. After
 // this number of iterations all new registrations will return `false`.
-// const ITERS: usize = 10;
+#[cfg(not(target_arch = "bpf"))]
+const ITERS: usize = 10;
 
 unsafe fn init() -> bool {
     if QUEUE.is_null() {
@@ -39,26 +39,27 @@ unsafe fn init() -> bool {
 
 pub fn cleanup() {
     // TODO causes LLVM to crash when compiling for BPF, not needed to BPF anyway for commented out
-    // for i in 1..=ITERS {
-    //     unsafe {
-    //         let queue = {
-    //             let _guard = LOCK.lock();
-    //             mem::replace(&mut QUEUE, if i == ITERS { DONE } else { ptr::null_mut() })
-    //         };
+    #[cfg(not(target_arch = "bpf"))]
+    for i in 1..=ITERS {
+        unsafe {
+            let queue = {
+                let _guard = LOCK.lock();
+                crate::mem::replace(&mut QUEUE, if i == ITERS { DONE } else { ptr::null_mut() })
+            };
 
-    //         // make sure we're not recursively cleaning up
-    //         assert!(queue != DONE);
+            // make sure we're not recursively cleaning up
+            assert!(queue != DONE);
 
-    //         // If we never called init, not need to cleanup!
-    //         if !queue.is_null() {
-    //             let queue: Box<Queue> = Box::from_raw(queue);
-    //             for to_run in *queue {
-    //                 // We are not holding any lock, so reentrancy is fine.
-    //                 to_run();
-    //             }
-    //         }
-    //     }
-    // }
+            // If we never called init, not need to cleanup!
+            if !queue.is_null() {
+                let queue: Box<Queue> = Box::from_raw(queue);
+                for to_run in *queue {
+                    // We are not holding any lock, so reentrancy is fine.
+                    to_run();
+                }
+            }
+        }
+    }
 }
 
 pub fn push(f: Box<dyn FnOnce()>) -> bool {

--- a/src/libstd/sys_common/at_exit_imp.rs
+++ b/src/libstd/sys_common/at_exit_imp.rs
@@ -38,6 +38,7 @@ unsafe fn init() -> bool {
 }
 
 pub fn cleanup() {
+    // TODO causes LLVM to crash when compiling for BPF, not needed to BPF anyway for commented out
     // for i in 1..=ITERS {
     //     unsafe {
     //         let queue = {

--- a/src/libstd/sys_common/thread.rs
+++ b/src/libstd/sys_common/thread.rs
@@ -4,13 +4,13 @@ use crate::sys::stack_overflow;
 use crate::sys::thread as imp;
 
 #[allow(dead_code)]
-pub unsafe fn start_thread(_main: *mut u8) {
+pub unsafe fn start_thread(main: *mut u8) {
     // Next, set up our stack overflow handler which may get triggered if we run
     // out of stack.
     let _handler = stack_overflow::Handler::new();
 
     // Finally, let's run some code.
-    // Box::from_raw(main as *mut Box<dyn FnOnce()>)()
+    Box::from_raw(main as *mut Box<dyn FnOnce()>)()
 }
 
 pub fn min_stack() -> usize {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -444,7 +444,7 @@ impl Builder {
     /// [`io::Result`]: ../../std/io/type.Result.html
     /// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
     #[unstable(feature = "thread_spawn_unchecked", issue = "55132")]
-    pub unsafe fn spawn_unchecked<'a, F, T>(self, f: F) -> io::Result<JoinHandle<T>> where
+    pub unsafe fn spawn_unchecked<'a, F, T>(self, _f: F) -> io::Result<JoinHandle<T>> where
         F: FnOnce() -> T, F: Send + 'a, T: Send + 'a
     {
         let Builder { name, stack_size } = self;
@@ -456,7 +456,7 @@ impl Builder {
 
         let my_packet : Arc<UnsafeCell<Option<Result<T>>>>
             = Arc::new(UnsafeCell::new(None));
-        let their_packet = my_packet.clone();
+        // let their_packet = my_packet.clone();
 
         let main = move || {
             if let Some(name) = their_thread.cname() {
@@ -468,9 +468,9 @@ impl Builder {
             let try_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 crate::sys_common::backtrace::__rust_begin_short_backtrace(f)
             }));
-            #[cfg(not(feature = "backtrace"))]
-            let try_result = panic::catch_unwind(panic::AssertUnwindSafe(f));
-            *their_packet.get() = Some(try_result);
+            // #[cfg(not(feature = "backtrace"))]
+            // let try_result = panic::catch_unwind(panic::AssertUnwindSafe(f));
+            // *their_packet.get() = Some(try_result);
         };
 
         Ok(JoinHandle(JoinInner {


### PR DESCRIPTION
- Now that the Rust BPF spec uses `os=unkown' remove workaround for linux stuff
- Rust's `liibstd` requires atomic compare and exchange, Rust BPF spec has been changed to indicate support, unwind workarounds and implement atomics directly.
- Bunch of other unwind and cleanup to minimize the difference between our fork and rust-lang